### PR TITLE
Take constants into account

### DIFF
--- a/lib/Test/Resub.pm
+++ b/lib/Test/Resub.pm
@@ -161,11 +161,8 @@ sub _restore_variables {
 sub _implements {
   my ($package, $sub) = @_;
 
-  local $@;
-  my %stash = eval "\%$package\::";
-  croak "finding $package\'s stash: $@\n" if $@;
-
-  return exists $stash{$sub} && *{$stash{$sub}}{CODE} && *{$stash{$sub}}{NAME} eq $sub;
+  no strict 'refs';
+  exists &{"$package\::$sub"};
 }
 
 sub _get_orig_code {

--- a/lib/Test/Resub.pm
+++ b/lib/Test/Resub.pm
@@ -197,6 +197,8 @@ sub _looks_moosey {
   return $meta;
 }
 
+use constant _NEED_LOCAL_WARN => "$]" < 5.016;
+
 sub swap_out {
   my ($self, $code, $is_destroy) = @_;
 
@@ -205,6 +207,7 @@ sub swap_out {
   my $do_simple_swap = sub {
     no strict 'refs';
     no warnings 'redefine';
+    local $SIG{__WARN__} = sub {} if _NEED_LOCAL_WARN;
     *{$name} = $code;
   };
 

--- a/t/01-main.t
+++ b/t/01-main.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 62;
+use Test::More tests => 63;
 
 # We need IO::Capture::Std(out|err) only for this test, so rather than
 # make the user install it for us, we have a copy for use in testing
@@ -441,3 +441,4 @@ sub stdout_of { return _std_of('IO::Capture::Stdout', @_) }
   my $rs = resub 'HasConstant::foo', sub () { 43 };
   is (HasConstant->foo, 43, 'resub works on constants');
 }
+is (HasConstant->foo, 42, 'constant gets restored');

--- a/t/01-main.t
+++ b/t/01-main.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 61;
+use Test::More tests => 62;
 
 # We need IO::Capture::Std(out|err) only for this test, so rather than
 # make the user install it for us, we have a copy for use in testing
@@ -431,4 +431,13 @@ sub stdout_of { return _std_of('IO::Capture::Stdout', @_) }
     eval { some::function(@args) };
   };
   like ( $error, qr/Can't store CODE items/, "our use of dclone() doesn't globally affect dclone" );
+}
+
+{
+  package HasConstant;
+  use constant foo => 42;
+}
+{
+  my $rs = resub 'HasConstant::foo', sub () { 43 };
+  is (HasConstant->foo, 43, 'resub works on constants');
 }


### PR DESCRIPTION
Snooping in stashes to see whether there is a typeglob with a CODE
entry will fail for constants created by ‘use constant’, which are
stored shorthand as scalar references.

In addition, perl 5.28 will introduce an optimisation whereby most
subs are stored as code refs in stashes, without needing a typeglob.
This commit gets all tests passing with bleadperl.